### PR TITLE
fixed issue_385

### DIFF
--- a/sources/29-web2py-english/05.markmin
+++ b/sources/29-web2py-english/05.markmin
@@ -1747,7 +1747,7 @@ There are a few features of this default layout that make it very easy to use an
 In views, you can turn on and customize sidebars as follows:
 
 ``
-{{left_sidebar_enable=True}}
+{{left_sidebar_enabled=True}}
 {{extend 'layout.html'}}
 
 This text goes in center


### PR DESCRIPTION
fixed issue 385
Ops. it is 384

chaper 05:
in the layout.html we find:

_left_sidebar_enabled_ = globals().get('left_sidebar_enabled',False)

but in the example we find: (left_sidebar_enable instead of left_sidebar_enabled, the "d" is missing)

{{left_sidebar_enable=True}}
{{extend 'layout.html'}}
This text goes in center
{{block left_sidebar}}
This text goes in sidebar
{{end}}