### PR TITLE
Python3 update

### DIFF
--- a/sources/29-web2py-english/00.markmin
+++ b/sources/29-web2py-english/00.markmin
@@ -2,7 +2,7 @@ I believe that the ability to easily build high quality web applications is of c
 
 Hence I started the ``web2py`` project in 2007, primarily as a teaching tool with the goal of making web development easier, faster, and more secure. Over time, it has managed to win the affection of thousands of knowledgeable users and hundreds of developers. Our collective effort has created one of the most full-featured Open Source Web Frameworks for enterprise web development.
 
-As a result, in 2011, ``web2py`` won the Bossie Award for best Open Source Development Software, and in 2012 it won the Technology of the Year award from InfoWorld.
+As a result, in 2011, ``web2py`` won the Bossie Award for best Open Source Development Software, and in 2012 it won the Technology of the Year award from InfoWorld. With the effort of a growing community, in 2017 web2py was finally refined in order to support Python 3 (but it is still compatible with the older Python 2.7 !).
 
 As you will learn in the following pages, ``web2py`` tries to lower the barrier of entry to web development by focusing on three main goals:
 

--- a/sources/29-web2py-english/01.markmin
+++ b/sources/29-web2py-english/01.markmin
@@ -31,7 +31,8 @@ administration interface to access the database and the tables.
 
 web2py differs from other web frameworks in that it is the only framework to fully embrace the Web 2.0
 paradigm, where the web is the computer. In fact, web2py does not require installation or configuration; it
-runs on any architecture that can run Python (Windows, Windows CE, Mac OS X, iOS, and Unix/Linux), and the development, deployment, and maintenance phases for the applications can be done via a local or remote web interface.  web2py runs with CPython (the C implementation) and PyPy (Python written in Python), on Python 2.7.
+runs on any architecture that can run Python (Windows, Windows CE, Mac OS X, iOS, and Unix/Linux), and the development, deployment, and maintenance phases for the applications can be done via a local or remote web interface.  
+web2py runs with CPython (the C implementation) and PyPy (Python written in Python), on Python 2.7 and Python 3.
 
 web2py provides a ticketing system for error events. If an error occurs, a ticket is issued to the user,
 and the error is logged for the administrator.
@@ -272,7 +273,7 @@ easily be modified or replaced.
 
 web2py is one of many web application frameworks, but it has compelling and unique features.
 web2py was originally developed as a teaching tool, with the following primary motivations:
-- Easy for users to learn server-side web development without compromising functionality. For this reason, web2py requires no installation and no configuration, has no dependencies (except for the source code distribution, which requires Python 2.7 and its standard library modules), and exposes most of its functionality via a Web interface, including an Integrated Development Environment with Debugger and database interface.
+- Easy for users to learn server-side web development without compromising functionality. For this reason, web2py requires no installation and no configuration, has no dependencies (except for the source code distribution, which requires Python 2.7 or 3.5+ and their standard library modules), and exposes most of its functionality via a Web interface, including an Integrated Development Environment with Debugger and database interface.
 - web2py has been stable from day one because it follows a top-down design; i.e., its API was designed before it was implemented. Even as new functionality has been added, web2py has never broken backwards compatibility, and it will not break compatibility when additional functionality is added in the future.
 - web2py proactively addresses the most important security issues which plague many modern web applications, as determined by OWASP``owasp``:cite  below.
 - web2py is lightweight. Its core libraries, including the Database Abstraction Layer, the template language, and all the helpers amount to 1.4MB. The entire source code including sample applications and images amounts to 10.4MB.
@@ -325,10 +326,10 @@ web2py is composed of the following components:
 web2py is distributed in source code, and in binary form for Microsoft Windows and for Mac OS X.
 
 The source code distribution can be used in any platform where Python runs and includes the above-mentioned components.
-To run the source code, you need Python 2.7 pre-installed on the system. You also need one of the supported database engines installed.
-For testing and light-demand applications, you can use the SQLite database, included with Python 2.7.
+To run the source code, you need Python 2.7 or Python 3.5+ pre-installed on the system. You also need one of the supported database engines installed.
+For testing and light-demand applications, you can use the SQLite database, included with Python.
 
-The binary versions of web2py (for Windows and Mac OS X) include a Python 2.7 interpreter and
+The binary versions of web2py (only for Windows and Mac OS X) include a Python 2.7 interpreter and
 the SQLite database. Technically, these two are not components of web2py. Including them in the binary distributions
 enables you to run web2py out of the box.
 
@@ -338,6 +339,20 @@ The following image depicts the overall web2py structure:
 
 
 At the bottom we find the interpreter. Moving up we find the web server (rocket), the libraries, and the applications. Each application consists for its own MVC design (models, controllers, views, modules, languages, databases, and static files). Each application includes its own database administration code (appadmin). Every web2py instance ships with three applications: welcome (the scaffolding app), admin (the web based IDE), and examples (copy of website and examples). 
+
+### Running web2py with Python 2 vs. Python 3
+
+When web2py was born, there was only Python version 2.5 available (in fact, Python 3.0 was released on December, 2008). 
+It took almost 10 years, but in 2017 web2py was finally made compatible with both Python 2.7 AND Python 3.5+. The older Python 2.6 is deprecated and no more supported with recent releases.
+
+Pyhon 3 compatibility was indeed a huge milestone (for many and many reasons) but it required a careful check and rewrite of most of the framework. 
+And the need of compatibility of all the required external libraries was a missing requirement for a long time.
+
+For new projects, we suggest you to use the latest release of web2py in the source form and to run it with Pyton 3.
+
+For existing projects, you should instead evaluate carefully what to do: remaining with Python 2 or begining the conversion of your application to Python 3. 
+Be careful: web2py apps created with python 2 require web2py running under python 2 and apps created using python 3 requires web2py running python 3. They cannot be mixed.
+
 
 ### About this book
 
@@ -375,7 +390,7 @@ There is also a formal issue tracker system on https://github.com/web2py/web2py/
 
 Any help is really appreciated. You can help other users on the user group, or by directly submitting patches on the program (at the GitHub site https://github.com/web2py/web2py). 
 Even if you find a typo on this book, or have an improvement on it, the best way to help is by patching the book itself (which is under the source folder of the repository 
-at https://github.com/mdipierro/web2py-book).
+at https://github.com/web2py/web2py-book).
 For more information on contributing, please see [[Chapter 15 ..\15]].
 
 [[web2py_style]]

--- a/sources/29-web2py-english/02.markmin
+++ b/sources/29-web2py-english/02.markmin
@@ -17,7 +17,7 @@ You may skip this chapter if you are already familiar with the Python language.
 
 ### Starting up
 ``shell``:inxx
-The binary distributions of web2py for Microsoft Windows or Apple OS X come packaged with the Python interpreter built into the distribution file itself.
+The binary distributions of web2py for Microsoft Windows or Apple OS X come packaged with the Python 2.7 interpreter built into the distribution file itself.
 
 You can start it on Windows with the following command (type at the DOS prompt):
 ``
@@ -34,7 +34,7 @@ On a Linux or other Unix box, chances are that you have Python already installed
 python web2py.py -S welcome
 ``:code
 
-If you do not have Python 2.7 already installed, you will have to download and install it before running web2py.
+If you do not have Python 2.7 or Python 3.5+ already installed, you will have to download and install it before running web2py from source.
 
 The ``-S welcome`` command line option instructs web2py to run the interactive shell as if the commands were executed in a controller for the **welcome** application, the web2py scaffolding application. This exposes almost all web2py classes, objects and functions to you. This is the only difference between the web2py interactive command line and the normal Python command line.
 

--- a/sources/29-web2py-english/03.markmin
+++ b/sources/29-web2py-english/03.markmin
@@ -4,7 +4,8 @@
 
 ``Linux``:inxx ``Mac``:inxx ``Windows``:inxx
 
-web2py comes in binary packages for Windows and Mac OS X. They include the Python interpreter so you do not need to have it pre-installed. There is also a source code version that runs on Windows, Mac, Linux, and other Unix systems. The source code package assumes that Python is already installed on the computer.
+web2py comes in binary packages for Windows and Mac OS X. They include the Python 2.7 interpreter so you do not need to have it pre-installed. 
+There is also a source code version that runs on Windows, Mac, Linux, and other Unix systems. The source code package assumes that Python 2.7 or 3.5 (or even newer) is already installed on the computer.
 
 web2py requires no installation. To get started, unzip the downloaded zip file for your specific operating system and execute the corresponding ``web2py`` file.
 
@@ -1597,7 +1598,7 @@ using the ``.git`` URL in the upload form. In this case you will also be enabled
 For example, you can locally install the application that shows this book on the web2py site with the URL:
 
 ``
-https://github.com/mdipierro/web2py-book.git
+https://github.com/web2py/web2py-book.git
 ``
 
 ------


### PR DESCRIPTION
I've added the compatibility with Python 3 where needed. 
And a specific new paragraph 1.8 = "Running web2py with Python 2 vs. Python 3" 