### PR TITLE
Fix JSON MIME-type

### DIFF
--- a/sources/29-web2py-english/10.markmin
+++ b/sources/29-web2py-english/10.markmin
@@ -125,7 +125,7 @@ And here is the code for "generic.json"
 try:
     from gluon.serializers import json
     response.write(json(response._vars), escape=False)
-    response.headers['Content-Type'] = 'text/json'
+    response.headers['Content-Type'] = 'application/json'
 except:
     raise HTTP(405, 'no json')
 }}


### PR DESCRIPTION
The correct MIME type for JSON format is `application/json` rather than `text/json`.  This fixes said MIME type and fixes #344.