### PR TITLE
In belongs section, example references wrong table

### DIFF
--- a/sources/29-web2py-english/06.markmin
+++ b/sources/29-web2py-english/06.markmin
@@ -2627,7 +2627,7 @@ In those cases where a nested select is required and the look-up field is a refe
 db.define_table('person', Field('name'))
 db.define_table('thing',
                 Field('name'),
-                Field('owner_id', 'reference thing'))
+                Field('owner_id', 'reference person'))
 
 db(db.thing.owner_id.belongs(db.person.name == 'Jonathan')).select()
 ``:code


### PR DESCRIPTION
In the 'belongs' section, under the example for "those cases where a nested select is required and the look-up field is a reference..." the example defines table person, then table thing, with owner_id referring to itself (thing).  In this example, owner_id should reference the person table, not the thing table.